### PR TITLE
Add command line options to disable optimization for some actions

### DIFF
--- a/src/ratbreeder.cc
+++ b/src/ratbreeder.cc
@@ -157,5 +157,7 @@ double WhiskerImprover::improve( Whisker & whisker_to_improve )
     }
   }
 
+  cout << "Chose " << whisker_to_improve.str() << endl;
+
   return score_to_beat_;
 }

--- a/src/ratbreeder.cc
+++ b/src/ratbreeder.cc
@@ -20,14 +20,14 @@ void RatBreeder::apply_best_split( WhiskerTree & whiskers, const unsigned int ge
     WhiskerTree bisected_whisker( *my_whisker, true );
 
     if ( bisected_whisker.num_children() == 1 ) {
-      //      printf( "Got unbisectable whisker! %s\n", my_whisker->str().c_str() );
+      printf( "Got unbisectable whisker! %s\n", my_whisker->str().c_str() );
       auto mutable_whisker( *my_whisker );
       mutable_whisker.promote( generation + 1 );
       assert( outcome.used_whiskers.replace( mutable_whisker ) );
       continue;
     }
 
-    //    printf( "Bisecting === %s === into === %s ===\n", my_whisker->str().c_str(), bisected_whisker.str().c_str() );
+    printf( "Bisecting === %s === into === %s ===\n", my_whisker->str().c_str(), bisected_whisker.str().c_str() );
     assert( whiskers.replace( *my_whisker, bisected_whisker ) );
     break;
   }

--- a/src/ratbreeder.hh
+++ b/src/ratbreeder.hh
@@ -7,31 +7,46 @@
 #include "configrange.hh"
 #include "evaluator.hh"
 
+struct WhiskerImproverOptions
+{
+  bool optimize_window_increment = true;
+  bool optimize_window_multiple = true;
+  bool optimize_intersend = true;
+};
+
+struct RatBreederOptions
+{
+  ConfigRange config_range = ConfigRange();
+  WhiskerImproverOptions improver_options = WhiskerImproverOptions();
+};
+
 class WhiskerImprover
 {
 private:
   const Evaluator eval_;
 
   WhiskerTree rat_;
+  WhiskerImproverOptions options_;
 
   std::unordered_map< Whisker, double, boost::hash< Whisker > > eval_cache_ {};
 
   double score_to_beat_;
 
 public:
-  WhiskerImprover( const Evaluator & evaluator, const WhiskerTree & rat, const double score_to_beat );
+  WhiskerImprover( const Evaluator & evaluator, const WhiskerTree & rat, const WhiskerImproverOptions & options,
+                   const double score_to_beat );
   double improve( Whisker & whisker_to_improve );
 };
 
 class RatBreeder
 {
 private:
-  ConfigRange _range;
+  RatBreederOptions _options;
 
   void apply_best_split( WhiskerTree & whiskers, const unsigned int generation ) const;
 
 public:
-  RatBreeder( const ConfigRange & s_range ) : _range( s_range ) {}
+  RatBreeder( const RatBreederOptions & s_options ) : _options( s_options ) {}
 
   Evaluator::Outcome improve( WhiskerTree & whiskers );
 };

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -80,7 +80,8 @@ int main( int argc, char *argv[] )
   }
 
   if ( config_filename.empty() ) {
-    fprintf( stderr, "Provide an input config protobuf (generated using './configure'). \n");
+    fprintf( stderr, "An input configuration protobuf must be provided via the cf= option. \n");
+    fprintf( stderr, "You can generate one using './configuration'. \n");
     exit ( 1 );
   }
 

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -15,6 +15,7 @@ int main( int argc, char *argv[] )
 {
   WhiskerTree whiskers;
   string output_filename;
+  RatBreederOptions options;
   RemyBuffers::ConfigRange input_config;
   string config_filename;
 
@@ -39,8 +40,27 @@ int main( int argc, char *argv[] )
 	perror( "close" );
 	exit( 1 );
       }
+
     } else if ( arg.substr( 0, 3 ) == "of=" ) {
       output_filename = string( arg.substr( 3 ) );
+
+    } else if ( arg.substr( 0, 4 ) == "opt=" ) {
+      options.improver_options.optimize_window_increment = false;
+      options.improver_options.optimize_window_multiple = false;
+      options.improver_options.optimize_intersend = false;
+      for ( char & c : arg.substr( 4 ) ) {
+        if ( c == 'b' ) {
+          options.improver_options.optimize_window_increment = true;
+        } else if ( c == 'm' ) {
+          options.improver_options.optimize_window_multiple = true;
+        } else if ( c == 'r' ) {
+          options.improver_options.optimize_intersend = true;
+        } else {
+          fprintf( stderr, "Invalid optimize option: %c\n", c );
+          exit( 1 );
+        }
+      }
+
     } else if ( arg.substr(0, 3 ) == "cf=" ) {
       config_filename = string( arg.substr( 3 ) );
       int cfd = open( config_filename.c_str(), O_RDONLY );
@@ -65,36 +85,39 @@ int main( int argc, char *argv[] )
   }
 
 
-  ConfigRange configuration_range;
-  
-  configuration_range.link_ppt = Range( input_config.link_packets_per_ms() );
-  configuration_range.rtt = Range( input_config.rtt() ); 
-  configuration_range.num_senders = Range( input_config.num_senders() ); 
-  configuration_range.mean_on_duration = Range( input_config.mean_on_duration() ); 
-  configuration_range.mean_off_duration = Range( input_config.mean_off_duration() );
-  configuration_range.buffer_size = Range( input_config.buffer_size() ); 
+  options.config_range.link_ppt = Range( input_config.link_packets_per_ms() );
+  options.config_range.rtt = Range( input_config.rtt() );
+  options.config_range.num_senders = Range( input_config.num_senders() );
+  options.config_range.mean_on_duration = Range( input_config.mean_on_duration() );
+  options.config_range.mean_off_duration = Range( input_config.mean_off_duration() );
+  options.config_range.buffer_size = Range( input_config.buffer_size() );
 
-  RatBreeder breeder( configuration_range );
+  RatBreeder breeder( options );
+
   unsigned int run = 0;
 
   printf( "#######################\n" );
   printf( "Optimizing for link packets_per_ms in [%f, %f]\n",
-	  configuration_range.link_ppt.low,
-	  configuration_range.link_ppt.high );
+	  options.config_range.link_ppt.low,
+	  options.config_range.link_ppt.high );
   printf( "Optimizing for rtt_ms in [%f, %f]\n",
-	  configuration_range.rtt.low,
-	  configuration_range.rtt.high );
+	  options.config_range.rtt.low,
+	  options.config_range.rtt.high );
   printf( "Optimizing for num_senders in [%f, %f]\n",
-	  configuration_range.num_senders.low, configuration_range.num_senders.high );
+	  options.config_range.num_senders.low, options.config_range.num_senders.high );
   printf( "Optimizing for mean_on_duration in [%f, %f], mean_off_duration in [ %f, %f]\n",
-	  configuration_range.mean_on_duration.low, configuration_range.mean_on_duration.high, configuration_range.mean_off_duration.low, configuration_range.mean_off_duration.high );
-  if ( configuration_range.buffer_size.low != numeric_limits<unsigned int>::max() ) {
+	  options.config_range.mean_on_duration.low, options.config_range.mean_on_duration.high, options.config_range.mean_off_duration.low, options.config_range.mean_off_duration.high );
+  printf( "Optimizing window increment: %d, window multiple: %d, intersend: %d\n",
+          options.improver_options.optimize_window_increment, options.improver_options.optimize_window_multiple,
+          options.improver_options.optimize_intersend);
+  if ( options.config_range.buffer_size.low != numeric_limits<unsigned int>::max() ) {
     printf( "Optimizing for buffer_size in [%f, %f]\n",
-            configuration_range.buffer_size.low,
-            configuration_range.buffer_size.high );
+            options.config_range.buffer_size.low,
+            options.config_range.buffer_size.high );
   } else {
     printf( "Optimizing for infinitely sized buffers. \n");
   }
+
   printf( "Initial rules (use if=FILENAME to read from disk): %s\n", whiskers.str().c_str() );
   printf( "#######################\n" );
 
@@ -140,7 +163,7 @@ int main( int argc, char *argv[] )
       }
 
       auto remycc = whiskers.DNA();
-      remycc.mutable_config()->CopyFrom( configuration_range.DNA() );
+      remycc.mutable_config()->CopyFrom( options.config_range.DNA() );
       remycc.mutable_optimizer()->CopyFrom( Whisker::get_optimizer().DNA() );
       remycc.mutable_configvector()->CopyFrom( training_configs );
       if ( not remycc.SerializeToFileDescriptor( fd ) ) {

--- a/src/whisker.cc
+++ b/src/whisker.cc
@@ -43,15 +43,18 @@ bool Whisker::OptimizationSetting< T >::eligible_value( const T & value ) const
 }
 
 template < typename T >
-vector< T > Whisker::OptimizationSetting< T >::alternatives( const T & value ) const
+vector< T > Whisker::OptimizationSetting< T >::alternatives( const T & value, bool active ) const
 {
   assert( eligible_value( value ) );
 
   vector< T > ret( 1, value );
 
+  /* If this axis isn't active, return only the current value. */
+  if (!active) return ret;
+
   for ( T proposed_change = min_change;
-	proposed_change <= max_change;
-	proposed_change *= multiplier ) {
+        proposed_change <= max_change;
+        proposed_change *= multiplier ) {
     /* explore positive change */
     const T proposed_value_up = value + proposed_change;
     const T proposed_value_down = value - proposed_change;
@@ -68,15 +71,15 @@ vector< T > Whisker::OptimizationSetting< T >::alternatives( const T & value ) c
   return ret;
 }
 
-vector< Whisker > Whisker::next_generation( void ) const
+vector< Whisker > Whisker::next_generation( bool optimize_window_increment, bool optimize_window_multiple, bool optimize_intersend ) const
 {
   vector< Whisker > ret;
 
-  for ( const auto & alt_window : get_optimizer().window_increment.alternatives( _window_increment ) ) {
-    for ( const auto & alt_multiple : get_optimizer().window_multiple.alternatives( _window_multiple ) ) {
-      for ( const auto & alt_intersend : get_optimizer().intersend.alternatives( _intersend ) ) {
-	Whisker new_whisker { *this };
-	new_whisker._generation++;
+  for ( const auto & alt_window : get_optimizer().window_increment.alternatives( _window_increment, optimize_window_increment ) ) {
+    for ( const auto & alt_multiple : get_optimizer().window_multiple.alternatives( _window_multiple, optimize_window_multiple ) ) {
+      for ( const auto & alt_intersend : get_optimizer().intersend.alternatives( _intersend, optimize_intersend ) ) {
+        Whisker new_whisker { *this };
+        new_whisker._generation++;
 
 	new_whisker._window_increment = alt_window;
 	new_whisker._window_multiple = alt_multiple;

--- a/src/whisker.cc
+++ b/src/whisker.cc
@@ -45,7 +45,10 @@ bool Whisker::OptimizationSetting< T >::eligible_value( const T & value ) const
 template < typename T >
 vector< T > Whisker::OptimizationSetting< T >::alternatives( const T & value, bool active ) const
 {
-  assert( eligible_value( value ) );
+  if ( !eligible_value( value ) ) {
+    printf("Ineligible value: %s is not between %s and %s\n", to_string( value ).c_str(), to_string( min_value ).c_str(), to_string( max_value ).c_str());
+    assert(false);
+  }
 
   vector< T > ret( 1, value );
 
@@ -75,9 +78,22 @@ vector< Whisker > Whisker::next_generation( bool optimize_window_increment, bool
 {
   vector< Whisker > ret;
 
-  for ( const auto & alt_window : get_optimizer().window_increment.alternatives( _window_increment, optimize_window_increment ) ) {
-    for ( const auto & alt_multiple : get_optimizer().window_multiple.alternatives( _window_multiple, optimize_window_multiple ) ) {
-      for ( const auto & alt_intersend : get_optimizer().intersend.alternatives( _intersend, optimize_intersend ) ) {
+  auto window_increment_alternatives = get_optimizer().window_increment.alternatives( _window_increment, optimize_window_increment );
+  auto window_multiple_alternatives = get_optimizer().window_multiple.alternatives( _window_multiple, optimize_window_multiple );
+  auto intersend_alternatives = get_optimizer().intersend.alternatives( _intersend, optimize_intersend );
+
+  printf("Alternatives: window increment %u to %u, window multiple %f to %f, intersend %f to %f\n",
+         *(min_element(window_increment_alternatives.begin(), window_increment_alternatives.end())),
+         *(max_element(window_increment_alternatives.begin(), window_increment_alternatives.end())),
+         *(min_element(window_multiple_alternatives.begin(), window_multiple_alternatives.end())),
+         *(max_element(window_multiple_alternatives.begin(), window_multiple_alternatives.end())),
+         *(min_element(intersend_alternatives.begin(), intersend_alternatives.end())),
+         *(max_element(intersend_alternatives.begin(), intersend_alternatives.end()))
+  );
+
+  for ( const auto & alt_window : window_increment_alternatives ) {
+    for ( const auto & alt_multiple : window_multiple_alternatives ) {
+      for ( const auto & alt_intersend : intersend_alternatives ) {
         Whisker new_whisker { *this };
         new_whisker._generation++;
 

--- a/src/whisker.hh
+++ b/src/whisker.hh
@@ -34,7 +34,7 @@ public:
   const double & intersend( void ) const { return _intersend; }
   const MemoryRange & domain( void ) const { return _domain; }
 
-  std::vector< Whisker > next_generation( void ) const;
+  std::vector< Whisker > next_generation( bool optimize_window_increment, bool optimize_window_multiple, bool optimize_intersend ) const;
 
   void promote( const unsigned int generation );
 
@@ -67,7 +67,7 @@ public:
 
     T default_value;
 
-    std::vector< T > alternatives( const T & value ) const;
+    std::vector< T > alternatives( const T & value, bool active ) const;
     bool eligible_value( const T & value ) const;
 
     RemyBuffers::OptimizationSetting DNA( void ) const


### PR DESCRIPTION
Split of #26 into semantically distinct histories.

* Adds a `opt=(m|b|r)` command that chooses which actions to optimize (leaving the others as defaults). This changes the `ConfigRange` class structure to pass more options to Remy, by adding new `RatBreederOptions` and `WhiskerImproverOptions` classes that are similar in purpose. (`RatBreederOptions` contains instances of each of `WhiskerImproverOptions` and `ConfigRange`.) Neither of these currently have protobufs associated with them; `WhiskerImproverOptions` is specified only from the `opt=` in the command line.
* Uncomments and adds some debugging lines (to get better visibility into what the optimizer is doing)

The `opt=` command should not, in theory, break any existing functionality, but I'm still testing this to be sure. If not specified it just optimizes for all three actions, as it did originally.