### PR TITLE
Early bail out

### DIFF
--- a/src/evaluator.cc
+++ b/src/evaluator.cc
@@ -104,7 +104,7 @@ Evaluator::Outcome::Outcome( const AnswerBuffers::Outcome & dna )
 }
 
 Evaluator::Outcome Evaluator::score( WhiskerTree & run_whiskers,
-				    const bool trace, const double carefulness ) const
+				     const bool trace, const double carefulness ) const
 {
   return score( run_whiskers, _prng_seed, _configs, trace, TICK_COUNT * carefulness );
 }

--- a/src/evaluator.cc
+++ b/src/evaluator.cc
@@ -104,7 +104,7 @@ Evaluator::Outcome::Outcome( const AnswerBuffers::Outcome & dna )
 }
 
 Evaluator::Outcome Evaluator::score( WhiskerTree & run_whiskers,
-				     const bool trace, const unsigned int carefulness ) const
+				    const bool trace, const double carefulness ) const
 {
   return score( run_whiskers, _prng_seed, _configs, trace, TICK_COUNT * carefulness );
 }

--- a/src/evaluator.hh
+++ b/src/evaluator.hh
@@ -39,7 +39,7 @@ public:
 
   Outcome score( WhiskerTree & run_whiskers,
 		 const bool trace = false,
-		 const unsigned int carefulness = 1 ) const;
+     const double carefulness = 1) const;
 
   static Evaluator::Outcome parse_problem_and_evaluate( const ProblemBuffers::Problem & problem );
 

--- a/src/evaluator.hh
+++ b/src/evaluator.hh
@@ -38,8 +38,8 @@ public:
   ProblemBuffers::Problem DNA( const WhiskerTree & whiskers ) const;
 
   Outcome score( WhiskerTree & run_whiskers,
-		 const bool trace = false,
-     const double carefulness = 1) const;
+		const bool trace = false,
+		const double carefulness = 1) const;
 
   static Evaluator::Outcome parse_problem_and_evaluate( const ProblemBuffers::Problem & problem );
 

--- a/src/ratbreeder.cc
+++ b/src/ratbreeder.cc
@@ -1,5 +1,3 @@
-#include <iostream>
-#include <fstream>
 #include <cassert>
 #include <limits>
 #include <boost/accumulators/accumulators.hpp>
@@ -13,6 +11,7 @@ using namespace std;
 
 typedef accumulator_set< double, stats< tag::tail_quantile <boost::accumulators::right > > >
   accumulator_t_right;
+
 
 void RatBreeder::apply_best_split( WhiskerTree & whiskers, const unsigned int generation ) const
 {
@@ -118,27 +117,62 @@ WhiskerImprover::WhiskerImprover( const Evaluator & s_evaluator,
 
 void WhiskerImprover::evaluate_replacements(const vector<Whisker> &replacements,
     vector< pair< const Whisker &, future< pair< bool, double > > > > &scores,
-    const double carefulness) {
+    const double carefulness ) 
+{
   for ( const auto & test_replacement : replacements ) {
     if ( eval_cache_.find( test_replacement ) == eval_cache_.end() ) {
       /* need to fire off a new thread to evaluate */
       scores.emplace_back( test_replacement,
-               async( launch::async, [] ( const Evaluator & e,
-                              const Whisker & r,
-                              const WhiskerTree & rat,
-                              const double carefulness ) {
-                    WhiskerTree replaced_whiskertree( rat );
-                    const bool found_replacement __attribute((unused)) = replaced_whiskertree.replace( r );
-                    assert( found_replacement );
-                    return make_pair( true, e.score( replaced_whiskertree, false, carefulness ).score ); },
-                  eval_, test_replacement, rat_, carefulness ) );
+                           async( launch::async, [] ( const Evaluator & e,
+                                                      const Whisker & r,
+                                                      const WhiskerTree & rat,
+                                                      const double carefulness ) {
+                                    WhiskerTree replaced_whiskertree( rat );
+                                    const bool found_replacement __attribute((unused)) = replaced_whiskertree.replace( r );
+                                    assert( found_replacement );
+                                    return make_pair( true, e.score( replaced_whiskertree, false, carefulness ).score ); },
+                                  eval_, test_replacement, rat_, carefulness ) );
     } else {
       /* we already know the score */
       scores.emplace_back( test_replacement,
-               async( launch::deferred, [] ( const double value ) {
-                   return make_pair( false, value ); }, eval_cache_.at( test_replacement ) ) );
+        async( launch::deferred, [] ( const double value ) {
+               return make_pair( false, value ); }, eval_cache_.at( test_replacement ) ) );
     }
   } 
+}
+
+vector<Whisker> WhiskerImprover::early_bail_out( const vector< Whisker > &replacements,
+        const double carefulness, const double quantile_to_keep )
+{  
+  vector< pair< const Whisker &, future< pair< bool, double > > > > scores;
+  evaluate_replacements( replacements, scores, carefulness );
+  
+  accumulator_t_right acc(
+     tag::tail< boost::accumulators::right >::cache_size = scores.size() );
+  vector<double> raw_scores;
+  for ( auto & x : scores ) {
+    const double score( x.second.get().second );
+    acc( score );
+    raw_scores.push_back( score );
+  }
+  
+  /* Set the lower bound to be MAX_PERCENT_ERROR worse than the current best score */
+  double lower_bound = std::min( score_to_beat_ * (1 + MAX_PERCENT_ERROR), 
+        score_to_beat_ * (1 - MAX_PERCENT_ERROR) );
+  /* Get the score at given quantile */
+  double quantile_bound = quantile( acc, quantile_probability = 1 - quantile_to_keep );
+  double cutoff = std::max( lower_bound, quantile_bound );
+
+  /* Discard replacements below threshold */
+  vector<Whisker> top_replacements;
+  for ( uint i = 0; i < scores.size(); i ++ ) {
+    const Whisker & replacement( scores.at( i ).first );
+    const double score( raw_scores.at( i ) );
+    if ( score >= cutoff ) {
+      top_replacements.push_back( replacement );
+    }
+  }
+  return top_replacements;
 }
 
 double WhiskerImprover::improve( Whisker & whisker_to_improve )
@@ -148,63 +182,28 @@ double WhiskerImprover::improve( Whisker & whisker_to_improve )
                                                          options_.optimize_intersend ) );
   vector< pair< const Whisker &, future< pair< bool, double > > > > scores;
 
-  /* Run for 5% simulation time to get estimates for the final score */
-  evaluate_replacements(replacements, scores, 0.05);
-  vector<double> raw_scores;
-  for ( auto & x : scores ) {
-    const double score( x.second.get().second );
-    raw_scores.push_back(score);
-  }
-  double best_score = *std::max_element(raw_scores.begin(), raw_scores.end());
-  double lower_bound = std::min(best_score * (1 + PERCENT_ERROR), 
-    best_score * (1 - PERCENT_ERROR));
-  vector<Whisker> top_replacements;
-  for ( uint i = 0; i < scores.size(); i ++ ) {
-    const Whisker & replacement( scores.at(i).first );
-    const double score( raw_scores.at(i) );
-    if ( score >= lower_bound ) {
-      top_replacements.push_back(replacement);
-    }
-  }
+  /* Run for 10% simulation time to get estimates for the final score 
+     and discard bad performing ones early on. */
+  vector<Whisker> top_replacements = early_bail_out( replacements, 0.1, 0.5 );
 
   /* find best replacement */
-  scores.clear();
-  evaluate_replacements(replacements, scores, 1);
-  raw_scores.clear();
+  evaluate_replacements( top_replacements, scores, 1 );
   for ( auto & x : scores ) {
-    const double score( x.second.get().second );
-    raw_scores.push_back(score);
-  }
-  best_score = *std::max_element(raw_scores.begin(), raw_scores.end());
-  lower_bound = std::min(best_score * (1 + PERCENT_ERROR), 
-    best_score * (1 - PERCENT_ERROR));
-  vector<Whisker> full_top_replacements;
-  for ( uint i = 0; i < scores.size(); i ++ ) {
-    const Whisker & replacement( scores.at(i).first );
-    const double score( raw_scores.at(i) );
-    if ( score >= lower_bound ) {
-      full_top_replacements.push_back(replacement);
-    }
-    if ( score > score_to_beat_ ) {
+     const Whisker & replacement( x.first );
+     const auto outcome( x.second.get() );
+     const bool was_new_evaluation( outcome.first );
+     const double score( outcome.second );
+
+     /* should we cache this result? */
+     if ( was_new_evaluation ) {
+       eval_cache_.insert( make_pair( replacement, score ) );
+     }
+
+     if ( score > score_to_beat_ ) {
       score_to_beat_ = score;
       whisker_to_improve = replacement;
-    }
+     }
   }
-  
-  int c2 = 0;
-  for (auto & w2 : full_top_replacements) {
-    for (auto & w1 : top_replacements) {
-      if (w1 == w2) {
-        c2 ++;
-        break;
-      }
-    }
-  }
-  std::fstream fs;
-  fs.open("PERCENT_ERROR.txt", std::fstream::in | std::fstream::out | std::fstream::app);
-  fs << c2  << " " << full_top_replacements.size() << " " 
-    << top_replacements.size() << " " << replacements.size() <<"\n";
-  fs.close();
 
   cout << "Chose " << whisker_to_improve.str() << endl;
 

--- a/src/ratbreeder.cc
+++ b/src/ratbreeder.cc
@@ -1,12 +1,17 @@
 #include <iostream>
-#include <vector>
 #include <cassert>
-#include <future>
 #include <limits>
+#include <boost/accumulators/accumulators.hpp>
+#include <boost/accumulators/statistics.hpp>
+#include <boost/accumulators/statistics/tail_quantile.hpp>
 
 #include "ratbreeder.hh"
 
+using namespace boost::accumulators;
 using namespace std;
+
+typedef accumulator_set< double, stats< tag::tail_quantile <boost::accumulators::right > > >
+  accumulator_t_right;
 
 void RatBreeder::apply_best_split( WhiskerTree & whiskers, const unsigned int generation ) const
 {
@@ -110,35 +115,62 @@ WhiskerImprover::WhiskerImprover( const Evaluator & s_evaluator,
     score_to_beat_( score_to_beat )
 {}
 
-double WhiskerImprover::improve( Whisker & whisker_to_improve )
-{
-  auto replacements( whisker_to_improve.next_generation( options_.optimize_window_increment,
-                                                         options_.optimize_window_multiple,
-                                                         options_.optimize_intersend) );
-
-  vector< pair< const Whisker &, future< pair< bool, double > > > > scores;
-
-  /* find best replacement */
+void WhiskerImprover::evaluate_replacements(const vector<Whisker> &replacements,
+    vector< pair< const Whisker &, future< pair< bool, double > > > > &scores,
+    const double carefulness) {
   for ( const auto & test_replacement : replacements ) {
     if ( eval_cache_.find( test_replacement ) == eval_cache_.end() ) {
       /* need to fire off a new thread to evaluate */
       scores.emplace_back( test_replacement,
-			   async( launch::async, [] ( const Evaluator & e,
-						      const Whisker & r,
-						      const WhiskerTree & rat ) {
-				    WhiskerTree replaced_whiskertree( rat );
-				    const bool found_replacement __attribute((unused)) = replaced_whiskertree.replace( r );
-				    assert( found_replacement );
-				    return make_pair( true, e.score( replaced_whiskertree ).score ); },
-				  eval_, test_replacement, rat_ ) );
+               async( launch::async, [] ( const Evaluator & e,
+                              const Whisker & r,
+                              const WhiskerTree & rat,
+                              const double carefulness ) {
+                    WhiskerTree replaced_whiskertree( rat );
+                    const bool found_replacement __attribute((unused)) = replaced_whiskertree.replace( r );
+                    assert( found_replacement );
+                    return make_pair( true, e.score( replaced_whiskertree, false, carefulness ).score ); },
+                  eval_, test_replacement, rat_, carefulness ) );
     } else {
       /* we already know the score */
       scores.emplace_back( test_replacement,
-			   async( launch::deferred, [] ( const double value ) {
-			       return make_pair( false, value ); }, eval_cache_.at( test_replacement ) ) );
+               async( launch::deferred, [] ( const double value ) {
+                   return make_pair( false, value ); }, eval_cache_.at( test_replacement ) ) );
+    }
+  } 
+}
+
+double WhiskerImprover::improve( Whisker & whisker_to_improve )
+{
+  auto replacements( whisker_to_improve.next_generation( options_.optimize_window_increment,
+                                                         options_.optimize_window_multiple,
+                                                         options_.optimize_intersend ) );
+  vector< pair< const Whisker &, future< pair< bool, double > > > > scores;
+
+  /* Run for 5% simulation time to get estimates for the final score */
+  evaluate_replacements(replacements, scores, 0.05);
+  accumulator_t_right acc(
+    tag::tail< boost::accumulators::right >::cache_size = scores.size() );
+  vector<double> raw_scores;
+  for ( auto & x : scores ) {
+    const double score( x.second.get().second );
+    acc(score);
+    raw_scores.push_back(score);
+  }
+  /* Keep only the top OPTIMIZATION_FACTOR of the replacements */
+  double cutoff = quantile(acc, quantile_probability = 1- OPT_FACTOR );
+  vector<Whisker> top_replacements;
+  for ( uint i = 0; i < scores.size(); i ++ ) {
+    const Whisker & replacement( scores.at(i).first );
+    const double score( raw_scores.at(i) );
+    if ( score >= cutoff ) {
+      top_replacements.push_back(replacement);
     }
   }
 
+  /* find best replacement */
+  scores.clear();
+  evaluate_replacements(top_replacements, scores, 1);
   /* find the best one */
   for ( auto & x : scores ) {
     const Whisker & replacement( x.first );

--- a/src/ratbreeder.hh
+++ b/src/ratbreeder.hh
@@ -3,6 +3,8 @@
 
 #include <unordered_map>
 #include <boost/functional/hash.hpp>
+#include <future>
+#include <vector>
 
 #include "configrange.hh"
 #include "evaluator.hh"
@@ -23,6 +25,7 @@ struct RatBreederOptions
 class WhiskerImprover
 {
 private:
+  static constexpr double OPT_FACTOR = 0.1; /* Only fully evaluate the top OPT_FACTOR replacements */
   const Evaluator eval_;
 
   WhiskerTree rat_;
@@ -31,6 +34,10 @@ private:
   std::unordered_map< Whisker, double, boost::hash< Whisker > > eval_cache_ {};
 
   double score_to_beat_;
+
+  void evaluate_replacements(const std::vector< Whisker > &replacements,
+    std::vector< std::pair< const Whisker &, std::future< std::pair< bool, double > > > > &scores,
+    const double carefulness);
 
 public:
   WhiskerImprover( const Evaluator & evaluator, const WhiskerTree & rat, const WhiskerImproverOptions & options,

--- a/src/ratbreeder.hh
+++ b/src/ratbreeder.hh
@@ -25,7 +25,7 @@ struct RatBreederOptions
 class WhiskerImprover
 {
 private:
-  static constexpr double OPT_FACTOR = 0.1; /* Only fully evaluate the top OPT_FACTOR replacements */
+  static constexpr double PERCENT_ERROR = 0.3;
   const Evaluator eval_;
 
   WhiskerTree rat_;

--- a/src/ratbreeder.hh
+++ b/src/ratbreeder.hh
@@ -25,7 +25,7 @@ struct RatBreederOptions
 class WhiskerImprover
 {
 private:
-  static constexpr double PERCENT_ERROR = 0.3;
+  const double MAX_PERCENT_ERROR = 0.05;
   const Evaluator eval_;
 
   WhiskerTree rat_;
@@ -38,6 +38,9 @@ private:
   void evaluate_replacements(const std::vector< Whisker > &replacements,
     std::vector< std::pair< const Whisker &, std::future< std::pair< bool, double > > > > &scores,
     const double carefulness);
+
+  std::vector<Whisker> early_bail_out(const std::vector< Whisker > &replacements,
+        const double carefulness, const double quantile_to_keep);
 
 public:
   WhiskerImprover( const Evaluator & evaluator, const WhiskerTree & rat, const WhiskerImproverOptions & options,


### PR DESCRIPTION
Ratbreeder now first looks at scores for all replacements for 10% simulation time, and discard replacements that are below a certain threshold. 

The threshold is currently set as the max between median of all scores and 95% (or 105% if the score is negative) of the best score from last round.  