### PR TITLE
Option to specify how many ticks the simulation should run for

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ Makefile.in
 /src/rat-runner
 /src/remy
 /src/scoring-example
+/src/*.pb.cc
+/src/*.pb.h

--- a/protobufs/dna.proto
+++ b/protobufs/dna.proto
@@ -65,6 +65,7 @@ message ConfigRange {
   optional Range buffer_size = 74;
   optional Range mean_off_duration = 75;
   optional Range mean_on_duration = 76;
+  optional uint32 simulation_ticks = 77;
 }
 
 message NetConfig {

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+last
+results

--- a/src/configrange.cc
+++ b/src/configrange.cc
@@ -11,8 +11,29 @@ static RemyBuffers::Range pair_to_range( const Range &p )
   return ret;
 }
 
-RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
+ConfigRange::ConfigRange( void ) :
+  link_ppt( Range() ),
+  rtt( Range() ),
+  mean_on_duration( Range() ),
+  mean_off_duration( Range() ),
+  num_senders( Range() ),
+  buffer_size( Range() ),
+  simulation_ticks( 1000000 )
+{
+}
 
+ConfigRange::ConfigRange( RemyBuffers::ConfigRange input_config ) :
+  link_ppt( Range( input_config.link_packets_per_ms() ) ),
+  rtt( Range( input_config.rtt() ) ),
+  mean_on_duration( Range( input_config.mean_on_duration() ) ),
+  mean_off_duration( Range( input_config.mean_off_duration() ) ),
+  num_senders( Range( input_config.num_senders() ) ),
+  buffer_size( Range( input_config.buffer_size() ) ),
+  simulation_ticks( input_config.simulation_ticks() )
+{
+}
+
+RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
 {
   RemyBuffers::ConfigRange ret;
   ret.mutable_link_packets_per_ms()->CopyFrom( pair_to_range( link_ppt) );

--- a/src/configrange.cc
+++ b/src/configrange.cc
@@ -20,7 +20,8 @@ RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
   ret.mutable_num_senders()->CopyFrom( pair_to_range( num_senders ) );
   ret.mutable_mean_on_duration()->CopyFrom( pair_to_range( mean_on_duration ) );
   ret.mutable_mean_off_duration()->CopyFrom( pair_to_range( mean_off_duration ) );
-  ret.mutable_buffer_size()->CopyFrom( pair_to_range( buffer_size ) );  
+  ret.mutable_buffer_size()->CopyFrom( pair_to_range( buffer_size ) );
+  ret.set_simulation_ticks( simulation_ticks );
 
   return ret;
 }

--- a/src/configrange.hh
+++ b/src/configrange.hh
@@ -42,7 +42,8 @@ public:
   Range mean_off_duration = Range();
   Range num_senders = Range();
   Range buffer_size = Range();
- 
+  unsigned int simulation_ticks = 1000000;
+
   RemyBuffers::ConfigRange DNA( void ) const;
 };
 

--- a/src/configrange.hh
+++ b/src/configrange.hh
@@ -8,7 +8,7 @@ public:
   double low;
   double high;
   double incr;
-  Range ( void ) 
+  Range ( void )
     : low( 1 ),
       high ( 1 ),
       incr ( 0 )
@@ -36,14 +36,16 @@ public:
 class ConfigRange
 {
 public:
-  Range link_ppt = Range();
-  Range rtt = Range();
-  Range mean_on_duration = Range();
-  Range mean_off_duration = Range();
-  Range num_senders = Range();
-  Range buffer_size = Range();
-  unsigned int simulation_ticks = 1000000;
+  Range link_ppt;
+  Range rtt;
+  Range mean_on_duration;
+  Range mean_off_duration;
+  Range num_senders;
+  Range buffer_size;
+  unsigned int simulation_ticks;
 
+  ConfigRange( void );
+  ConfigRange( RemyBuffers::ConfigRange configrange );
   RemyBuffers::ConfigRange DNA( void ) const;
 };
 

--- a/src/evaluator.cc
+++ b/src/evaluator.cc
@@ -7,10 +7,9 @@
 #include "network.cc"
 #include "rat-templates.cc"
 
-const unsigned int TICK_COUNT = 1000000;
-
 Evaluator::Evaluator( const ConfigRange & range )
   : _prng_seed( global_PRNG()() ), /* freeze the PRNG seed for the life of this Evaluator */
+    _tick_count( range.simulation_ticks ),
     _configs()
 {
   // add configs from every point in the cube of configs
@@ -43,7 +42,7 @@ ProblemBuffers::Problem Evaluator::DNA( const WhiskerTree & whiskers ) const
 
   ProblemBuffers::ProblemSettings settings;
   settings.set_prng_seed( _prng_seed );
-  settings.set_tick_count( TICK_COUNT );
+  settings.set_tick_count( _tick_count );
 
   ret.mutable_settings()->CopyFrom( settings );
 
@@ -106,7 +105,7 @@ Evaluator::Outcome::Outcome( const AnswerBuffers::Outcome & dna )
 Evaluator::Outcome Evaluator::score( WhiskerTree & run_whiskers,
 				     const bool trace, const double carefulness ) const
 {
-  return score( run_whiskers, _prng_seed, _configs, trace, TICK_COUNT * carefulness );
+  return score( run_whiskers, _prng_seed, _configs, trace, _tick_count * carefulness );
 }
 
 

--- a/src/evaluator.hh
+++ b/src/evaluator.hh
@@ -29,6 +29,7 @@ public:
 
 private:
   const unsigned int _prng_seed;
+  unsigned int _tick_count;
 
   std::vector< NetConfig > _configs;
 

--- a/src/input-configrange.cc
+++ b/src/input-configrange.cc
@@ -74,6 +74,45 @@ bool update_config_with_range(RemyBuffers::Range * range, int argc,
   return true;
 }
 
+// Parses input arguments, sets a uint32 field.
+// If mandatory is false and no input arguments are found, skips and returns false.
+// If the input arugments are invalid, or if mandatory is true and no input arguments
+// are found, calls exit(1).
+// If all input arguments were found, updates the range and returns true.
+bool update_config_with_uint32(RemyBuffers::ConfigRange & range,
+    void (RemyBuffers::ConfigRange::*set_fn)(unsigned int), int argc, char *argv[],
+    string arg_name, bool mandatory) {
+
+  bool found = false;
+  unsigned int value = -1;
+  int arg_name_size = arg_name.size();
+  for ( int i = 1; i < argc; i++ ) {
+    string arg( argv[i] );
+    if ( arg.substr( 0, arg_name_size+1 ) == arg_name + "=" ) {
+      found = true;
+      try {
+        value = stoul( arg.substr( arg_name_size+1 ) );
+      } catch ( invalid_argument ) {
+        fprintf( stderr, "Could not parse %s argument: %s", arg_name.c_str(), arg.c_str() );
+        exit(1);
+      }
+      break;
+    }
+  }
+  if ( !found && mandatory ) {
+    fprintf( stderr, "Please provide an argument for %s\n", arg_name.c_str() );
+    exit(1);
+  }
+  if ( found ) {
+    fprintf( stderr, "Setting %s to %u\n", arg_name.c_str(), value );
+    (range.*set_fn)(value);
+    return true;
+  }
+  fprintf( stderr, "No argument found for %s\n", arg_name.c_str() );
+  return false;
+}
+
+
 int main(int argc, char *argv[]) {
   string input_filename, output_filename;
   bool infinite_buffers = false;
@@ -120,6 +159,8 @@ int main(int argc, char *argv[]) {
   update_config_with_range(input_config.mutable_num_senders(), argc, argv, "nsrc", mandatory);
   update_config_with_range(input_config.mutable_mean_on_duration(), argc, argv, "on", mandatory);
   update_config_with_range(input_config.mutable_mean_off_duration(), argc, argv, "off", mandatory);
+
+  update_config_with_uint32(input_config, &RemyBuffers::ConfigRange::set_simulation_ticks, argc, argv, "ticks", mandatory);
 
   if ( !(infinite_buffers) ) {
     update_config_with_range(input_config.mutable_buffer_size(), argc, argv, "buf_size", mandatory);

--- a/src/rat-runner.cc
+++ b/src/rat-runner.cc
@@ -20,6 +20,7 @@ int main( int argc, char *argv[] )
   double mean_on_duration = 5000.0;
   double mean_off_duration = 5000.0;
   double buffer_size = numeric_limits<unsigned int>::max();
+  unsigned int simulation_ticks = 1000000;
 
   for ( int i = 1; i < argc; i++ ) {
     string arg( argv[ i ] );
@@ -81,6 +82,8 @@ int main( int argc, char *argv[] )
   configuration_range.mean_on_duration = Range( mean_on_duration, mean_on_duration, 0 );
   configuration_range.mean_off_duration = Range( mean_off_duration, mean_off_duration, 0 );
   configuration_range.buffer_size = Range( buffer_size, buffer_size, 0 );
+  configuration_range.simulation_ticks = simulation_ticks;
+
   Evaluator eval( configuration_range );
   auto outcome = eval.score( whiskers, false, 10 );
   printf( "score = %f\n", outcome.score );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -92,12 +92,15 @@ int main( int argc, char *argv[] )
   options.config_range.mean_on_duration = Range( input_config.mean_on_duration() );
   options.config_range.mean_off_duration = Range( input_config.mean_off_duration() );
   options.config_range.buffer_size = Range( input_config.buffer_size() );
+  options.config_range.simulation_ticks = input_config.simulation_ticks();
 
   RatBreeder breeder( options );
 
   unsigned int run = 0;
 
   printf( "#######################\n" );
+  printf( "Evaluator simulations will run for %d ticks\n",
+    options.config_range.simulation_ticks );
   printf( "Optimizing for link packets_per_ms in [%f, %f]\n",
 	  options.config_range.link_ppt.low,
 	  options.config_range.link_ppt.high );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -11,6 +11,12 @@
 #include "configrange.hh"
 using namespace std;
 
+void print_range( const Range & range, const string & name )
+{
+  printf( "Optimizing for %s over [%f : %f : %f]\n", name.c_str(),
+    range.low, range.incr, range.high );
+}
+
 int main( int argc, char *argv[] )
 {
   WhiskerTree whiskers;
@@ -76,7 +82,7 @@ int main( int argc, char *argv[] )
         perror( "close" );
         exit( 1 );
       }
-    } 
+    }
   }
 
   if ( config_filename.empty() ) {
@@ -101,23 +107,17 @@ int main( int argc, char *argv[] )
   printf( "#######################\n" );
   printf( "Evaluator simulations will run for %d ticks\n",
     options.config_range.simulation_ticks );
-  printf( "Optimizing for link packets_per_ms in [%f, %f]\n",
-	  options.config_range.link_ppt.low,
-	  options.config_range.link_ppt.high );
-  printf( "Optimizing for rtt_ms in [%f, %f]\n",
-	  options.config_range.rtt.low,
-	  options.config_range.rtt.high );
-  printf( "Optimizing for num_senders in [%f, %f]\n",
-	  options.config_range.num_senders.low, options.config_range.num_senders.high );
-  printf( "Optimizing for mean_on_duration in [%f, %f], mean_off_duration in [ %f, %f]\n",
-	  options.config_range.mean_on_duration.low, options.config_range.mean_on_duration.high, options.config_range.mean_off_duration.low, options.config_range.mean_off_duration.high );
   printf( "Optimizing window increment: %d, window multiple: %d, intersend: %d\n",
           options.improver_options.optimize_window_increment, options.improver_options.optimize_window_multiple,
           options.improver_options.optimize_intersend);
+  print_range( options.config_range.link_ppt, "link packets_per_ms" );
+  print_range( options.config_range.rtt, "rtt_ms" );
+  print_range( options.config_range.num_senders, "num_senders" );
+  print_range( options.config_range.mean_on_duration, "mean_on_duration" );
+  print_range( options.config_range.mean_off_duration, "mean_off_duration" );
+
   if ( options.config_range.buffer_size.low != numeric_limits<unsigned int>::max() ) {
-    printf( "Optimizing for buffer_size in [%f, %f]\n",
-            options.config_range.buffer_size.low,
-            options.config_range.buffer_size.high );
+    print_range( options.config_range.buffer_size, "buffer_size" );
   } else {
     printf( "Optimizing for infinitely sized buffers. \n");
   }
@@ -147,7 +147,7 @@ int main( int argc, char *argv[] )
           RemyBuffers::NetConfig* net_config = training_configs.add_config();
           *net_config = run.first.DNA();
           written = true;
-      
+
         }
       }
       printf( "===\nconfig: %s\n", run.first.str().c_str() );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -91,14 +91,7 @@ int main( int argc, char *argv[] )
     exit ( 1 );
   }
 
-
-  options.config_range.link_ppt = Range( input_config.link_packets_per_ms() );
-  options.config_range.rtt = Range( input_config.rtt() );
-  options.config_range.num_senders = Range( input_config.num_senders() );
-  options.config_range.mean_on_duration = Range( input_config.mean_on_duration() );
-  options.config_range.mean_off_duration = Range( input_config.mean_off_duration() );
-  options.config_range.buffer_size = Range( input_config.buffer_size() );
-  options.config_range.simulation_ticks = input_config.simulation_ticks();
+  options.config_range = ConfigRange( input_config );
 
   RatBreeder breeder( options );
 


### PR DESCRIPTION
These commits add an option to the configuration file to specify how many ticks the simulation should run for. In order to facilitate the conversion of existing configuration files, it also adds to `configuration` the ability to specify an input file for modification, rather than generating all files from command-line options only.

These changes are (or at least we think they are) orthogonal to #30. These changes only provide for the *maximum* time a simulation can run time, and provide no provision for early bail-out. Taken together, the changes in #30 (I think) would then do its first run on 10% of whatever is specified in the config file. I can rebase them after #30 is merged if that would be desirable.