### PR TITLE
Add ability to replot existing results to plot.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ Makefile.in
 /src/rat-runner
 /src/remy
 /src/scoring-example
+/src/*.pb.cc
+/src/*.pb.h

--- a/protobufs/dna.proto
+++ b/protobufs/dna.proto
@@ -65,6 +65,7 @@ message ConfigRange {
   optional Range buffer_size = 74;
   optional Range mean_off_duration = 75;
   optional Range mean_on_duration = 76;
+  optional uint32 simulation_ticks = 77;
 }
 
 message NetConfig {

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,2 @@
+last
+results

--- a/scripts/plot.py
+++ b/scripts/plot.py
@@ -4,6 +4,7 @@ This script requires Python 3."""
 
 import sys
 import os
+import shutil
 import argparse
 import subprocess
 import re
@@ -125,73 +126,178 @@ def parse_ratrunner_output(result):
 
     return norm_score, sender_data, link_ppt_prior
 
-def compute_normalized_score(remyccfilename, parameters, console_dir=None):
-    """Runs rat-runner on the given RemyCC `remyccfilename` and with the given
-    parameters, and returns the normalized score and sender throughputs and delays.
-    `parameters` is a dict of parameters.
-    """
-    kwargs = {}
-    if console_dir:
-        filename = "ratrunner-{remycc}-{link_ppt:f}.out".format(
-                remycc=os.path.basename(remyccfilename), **parameters)
-        filename = os.path.join(console_dir, filename)
-        kwargs["console_file"] = open(filename, "w")
-
-    output = run_ratrunner(remyccfilename, parameters, **kwargs)
-
-    if "console_file" in kwargs:
-        kwargs["console_file"].close()
-
-    return parse_ratrunner_output(output)
-
 def add_plot(axes, link_speeds, norm_scores, **kwargs):
     """Adds a plot for the given link-packets-per-ms `link_ppts` and normalized
     scores `norm_scores` to the `axes`."""
     return plt.semilogx(link_speeds, norm_scores, axes=axes, **kwargs)
 
-def generate_data_and_plot(remyccfilename, link_ppt_range, parameters, console_dir=None, data_dir=None, axes=None):
-    """For a given RemyCC `remyccfilename`, runs rat-runner once on each link
-    speed in `link_ppt_range` (each being specified in packets per millisecond),
-    with other parameters as specified in the dict `parameters`. Returns the
-    link rates specified under "prior assumptions".
 
-    If `console_dir` is specified, the outputs of each rat-runner run are stored in
-        a file (each) in that directory.
-    If `data_dir` is specified, data from the run is written to a (single) file in
-        that directory.
-    If `axes` is specified, a plot will be added to those axes.
+class BaseRemyCCPerformancePlotGenerator:
+    """Base class for generating and plotting data for a RemyCC.
+    Subclasses should provide a constructor and a `get_statistics` method.
+
+    `link_ppt_range` is an iterable of link speeds to plot.
+    `data_dir`, optional, is a directory in which a file for each `generate()`
+        call will be written. If omitted, data files will not be generated.
+    `axes`, optional, is a `matplotlib.Axes` object to which plots will be added.
+        If omitted, plots will not be generated.
+
+    `link_ppt_prior` may be specified, in which case it should be a value
+        returned by the `get_link_ppt_prior()` method of another generator. This
+        is useful for the daisy-chaining link_ppt_prior state of multiple
+        generators.
     """
-    if data_dir:
-        data_filename = "data-{remycc}.csv".format(
-                remycc=os.path.basename(remyccfilename))
-        data_file = open(os.path.join(data_dir, data_filename), "w")
-        data_csv = csv.writer(data_file)
 
-    norm_scores = []
-    npoints = len(link_ppt_range)
+    def __init__(self, link_ppt_range, **kwargs):
+        self.link_ppt_range = link_ppt_range
+        self.data_dir = kwargs.pop("data_dir", None)
+        self.axes = kwargs.pop("axes", None)
+        self._link_ppt_priors = kwargs.pop("link_ppt_priors", [])
+        if self._link_ppt_priors is None:
+            self._link_ppt_priors = []
 
-    for i, link_ppt in enumerate(link_ppt_range, start=1):
+        if len(kwargs) > 0:
+            raise TypeError("Unrecognized arguments: " + ", ".join(kwargs.keys()))
+
+    def get_statistics(self, remyccfilename, link_ppt):
+        raise NotImplementedError("subclasses of BaseRemyCCPerformancePlotGenerator must implement get_statistics")
+
+    def get_data_file(self, remyccfilename):
+        if self.data_dir:
+            data_filename = "data-{remycc}.csv".format(
+                    remycc=os.path.basename(remyccfilename))
+            data_file = open(os.path.join(self.data_dir, data_filename), "w")
+        else:
+            return None
+
+    def generate(self, remyccfilename):
+        data_file = self.get_data_file(remyccfilename)
+        if data_file:
+            data_csv = csv.writer(data_file)
+
+        norm_scores = []
+        npoints = len(self.link_ppt_range)
+
+        for i, link_ppt in enumerate(link_ppt_range, start=1):
+            print("\033[KGenerating score for if={:s}, link={:f} ({:d} of {:d})...".format(
+                        remyccfilename, link_ppt, i, npoints),
+                        file=sys.stderr, end='\r', flush=True)
+            norm_score, sender_data, link_ppt_prior = self.get_statistics(remyccfilename, link_ppt)
+            norm_scores.append(norm_score)
+            sender_numbers = chain(*sender_data)
+            if data_file:
+                data_csv.writerow([link_ppt, norm_score] + list(sender_numbers))
+            self._update_link_ppt_prior(link_ppt_prior)
+
+        if data_file:
+            data_file.close()
+
+        if self.axes:
+            print("\033[KPlotting for file {}...".format(remyccfilename), file=sys.stderr, end='\r', flush=True)
+            link_speeds = [LINK_PPT_TO_MBPS_CONVERSION*l for l in link_ppt_range]
+            add_plot(self.axes, link_speeds, norm_scores, label=remyccfilename)
+
+        print("\033[KDone file {}.".format(remyccfilename), file=sys.stderr)
+        sys.stderr.flush()
+
+    def _update_link_ppt_prior(self, link_ppt_prior):
+        if link_ppt_prior in self._link_ppt_priors:
+            return
+        self._link_ppt_priors.append(link_ppt_prior)
+
+    def get_link_ppt_priors(self):
+        """If the prior optimizion settings for each file on which generate()
+        has been called so far are the same, returns that setting. Otherwise,
+        returns None."""
+        return self._link_ppt_priors
+
+
+class RatRunnerFilesMixin:
+    """Provides functionality relating to rat-runner output files.
+    Subclass constructors must provide a `console_dir` attribute to objects of
+    the class, which may be None."""
+
+    def get_console_filename(self, remyccfilename, link_ppt):
+        filename = "ratrunner-{remycc}-{link_ppt:f}.out".format(
+                remycc=os.path.basename(remyccfilename), link_ppt=link_ppt)
+        filename = os.path.join(self.console_dir, filename)
+        return filename
+
+
+class RatRunnerRemyCCPerformancePlotGenerator(RatRunnerFilesMixin, BaseRemyCCPerformancePlotGenerator):
+    """Generates data and plots by invoking rat-runner to generate a score for
+    every point. In addition to the arguments taken by BaseRemyCCPerformancePlotGenerator:
+
+    `parameters` is a dictionary of parameters to pass to rat-runner.
+    `console_dir`, optional, is the directory to which rat-runner outputs will be written,
+        one file per data point.
+    """
+
+    def __init__(self, link_ppt_range, parameters, **kwargs):
+        self.parameters = parameters
+        self.console_dir = kwargs.pop("console_dir", None)
+        super(RatRunnerRemyCCPerformancePlotGenerator, self).__init__(link_ppt_range, **kwargs)
+
+    def get_statistics(self, remyccfilename, link_ppt):
+        """Runs rat-runner on the given RemyCC `remyccfilename` and with the given
+        parameters, and returns the normalized score and sender throughputs and delays.
+        """
+        parameters = dict(self.parameters)
         parameters["link_ppt"] = link_ppt
-        print("\033[KGenerating score for if={:s}, link={:f} ({:d} of {:d})...".format(
-                    remyccfilename, link_ppt, i, npoints),
-                    file=sys.stderr, end='\r', flush=True)
-        norm_score, sender_data, link_ppt_prior = compute_normalized_score(remyccfilename, parameters, console_dir)
-        norm_scores.append(norm_score)
-        sender_numbers = chain(*sender_data)
-        if data_dir:
-            data_csv.writerow([link_ppt, norm_score] + list(sender_numbers))
 
-    if axes:
-        print("\033[KPlotting for file {}...".format(remyccfilename), file=sys.stderr, end='\r', flush=True)
-        link_speeds = [LINK_PPT_TO_MBPS_CONVERSION*l for l in link_ppt_range]
-        add_plot(axes, link_speeds, norm_scores, label=remyccfilename)
+        kwargs = {}
+        if self.console_dir:
+            filename = self.get_console_filename(remyccfilename, link_ppt)
+            kwargs["console_file"] = open(filename, "w")
 
-    data_file.close()
+        output = run_ratrunner(remyccfilename, parameters, **kwargs)
 
-    print("\033[KDone file {}.".format(remyccfilename), file=sys.stderr)
-    sys.stderr.flush()
+        if "console_file" in kwargs:
+            kwargs["console_file"].close()
 
-    return link_ppt_prior
+        return parse_ratrunner_output(output)
+
+
+class OutputsDirectoryRemyCCPerformancePlotGenerator(RatRunnerFilesMixin, BaseRemyCCPerformancePlotGenerator):
+    """Generates data and plots by parsing outputs from an existing directory.
+    In addition to the arguments taken by BaseRemyCCPerformancePlotGenerator:
+
+    `console_dir` is the directory in which existing outputs are found. The
+    relevant outputs files must all exist with the correct names. If any don't,
+    `generate()` will print a warning and skip the point.
+    """
+
+    def __init__(self, link_ppt_range, console_dir, **kwargs):
+        self.console_dir = console_dir
+        super(OutputsDirectoryRemyCCPerformancePlotGenerator, self).__init__(link_ppt_range, **kwargs)
+
+    def get_statistics(self, remyccfilename, link_ppt):
+        filename = self.get_console_filename(remyccfilename, link_ppt)
+        f = open(filename, "r")
+        contents = f.read()
+        f.close()
+        return parse_ratrunner_output(contents)
+
+
+def process_replot_argument(replot_dir, results_dir):
+    """Reads the args.json file in a results directory, copies it to an
+    appropriate location in the current results directory and returns the link
+    speed range and a list of RemyCC files."""
+    argsfilename = os.path.join(replot_dir, "args.json")
+    argsfile = open(argsfilename)
+    jsondict = json.load(argsfile)
+    argsfile.close()
+    args = jsondict["args"]
+    remyccs = args["remycc"]
+    link_ppt_range = np.logspace(np.log10(args["link_ppt"][0]), np.log10(args["link_ppt"][1]), args["num_points"])
+    console_dir = os.path.join(replot_dir, "outputs")
+
+    replots_dirname = os.path.join(results_dir, "replots", os.path.basename(replot_dir))
+    os.makedirs(replots_dirname, exist_ok=True)
+    target_filename = os.path.join(replots_dirname, "args.json")
+    shutil.copy(argsfilename, target_filename)
+
+    return remyccs, link_ppt_range, console_dir
 
 def plot_from_original_file(datafilename, axes):
     """Plots data from the file `datafile` to the axes `axes`."""
@@ -223,6 +329,8 @@ def log_arguments(argsfile, args):
     json.dump(jsondict, argsfile, indent=2, sort_keys=True)
 
 def make_results_dir(dirname):
+    """Makes a results directory with the given name and directs 'last' symlink to it."""
+
     if dirname is None:
         dirname = os.path.join(DEFAULT_RESULTS_DIR, "results" + time.strftime("%Y%m%d-%H%M%S"))
     if os.path.islink("last"):
@@ -233,6 +341,10 @@ def make_results_dir(dirname):
     return dirname
 
 def generate_remyccs_list(specs):
+    """Returns a list of RemyCC files, for example:
+        ["myremycc.5"] -> ["myremycc.5"]
+        ["myremycc.[3:3:9]"] -> ["myremycc.3", "myremycc.6", "myremycc.9"]
+    """
     result = []
     for spec in specs:
         match = REMYCCSPEC_REGEX.match(spec)
@@ -258,6 +370,8 @@ def generate_remyccs_list(specs):
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument("remycc", nargs="*", type=str,
     help="RemyCC file(s) to run, can also use e.g. name.[5:5:30] to do name.5, name.10, ..., name.30")
+parser.add_argument("-R", "--replot", type=str, action="append", default=[],
+    help="Replot results in this directory from output files (can be specified multiple times)")
 parser.add_argument("-n", "--num-points", type=int, default=1000,
     help="Number of points to plot")
 parser.add_argument("-s", "--nsenders", type=int, default=2,
@@ -285,7 +399,10 @@ args = parser.parse_args()
 # Sanity-check arguments, warn user say they can stop things early
 if not os.path.isdir(args.originals):
     warn("The path {} is not a directory.".format(args.originals))
-if len(args.remycc) == 0:
+for replot_dir in args.replot:
+    if not os.path.isdir(replot_dir):
+        warn("The path {} is not a directory.".format(replot_dir))
+if len(args.remycc) == 0 and len(args.replot) == 0:
     warn("No RemyCC files specified, plotting only originals.")
 
 # Make directories
@@ -313,10 +430,20 @@ remyccfiles = generate_remyccs_list(args.remycc)
 ax = plt.axes()
 
 # Generate data and plots (the main part)
-link_ppt_priors = []
+generator = RatRunnerRemyCCPerformancePlotGenerator(link_ppt_range, parameters,
+        console_dir=console_dirname, data_dir=data_dirname, axes=ax)
 for remyccfile in remyccfiles:
-    link_ppt_prior = generate_data_and_plot(remyccfile, link_ppt_range, parameters, console_dirname, data_dirname, ax)
-    link_ppt_priors.append(link_ppt_prior)
+    generator.generate(remyccfile)
+link_ppt_priors = generator.get_link_ppt_priors()
+
+# Generate replots
+for replot_dir in args.replot:
+    remyccs, link_ppt_range, outputs_dir = process_replot_argument(replot_dir, results_dirname)
+    generator = OutputsDirectoryRemyCCPerformancePlotGenerator(link_ppt_range, outputs_dir,
+            link_ppt_priors=link_ppt_priors, data_dir=data_dirname, axes=ax)
+    for remycc in remyccs:
+        generator.generate(remycc)
+    link_ppt_priors = generator.get_link_ppt_priors()
 
 # Add the remaining plots
 if os.path.isdir(args.originals):
@@ -327,16 +454,13 @@ if os.path.isdir(args.originals):
         print("Plotting file {}...".format(path), file=sys.stderr)
         plot_from_original_file(path, ax)
 
-# If there were RemyCCs involved, check they all had the same training range.
-# If they did, highlight the range on the graph.
-if len(link_ppt_priors) > 0:
-    if not all([l == link_ppt_priors[0] for l in link_ppt_priors]):
-        print(set(link_ppt_priors))
-        warn("Not all RemyCCs had the same training range.")
-    else:
-        link_ppt_low, link_ppt_high = link_ppt_priors[0]
-        plt.axvspan(LINK_PPT_TO_MBPS_CONVERSION*link_ppt_low, LINK_PPT_TO_MBPS_CONVERSION*link_ppt_high,
-                linewidth=0.0, facecolor="0.2", alpha=0.2)
+# If all RemyCCs had the same training range, plot it on the graph.
+if len(link_ppt_priors) == 1:
+    link_ppt_low, link_ppt_high = link_ppt_priors[0]
+    plt.axvspan(LINK_PPT_TO_MBPS_CONVERSION*link_ppt_low, LINK_PPT_TO_MBPS_CONVERSION*link_ppt_high,
+            linewidth=0.0, facecolor="0.2", alpha=0.2)
+elif len(link_ppt_priors) > 1:
+    print("Multiple link_ppt_priors found, not highlighting on plot.")
 
 # Make plot pretty and save
 plot_filename = "link_ppt"

--- a/src/configrange.cc
+++ b/src/configrange.cc
@@ -11,8 +11,29 @@ static RemyBuffers::Range pair_to_range( const Range &p )
   return ret;
 }
 
-RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
+ConfigRange::ConfigRange( void ) :
+  link_ppt( Range() ),
+  rtt( Range() ),
+  mean_on_duration( Range() ),
+  mean_off_duration( Range() ),
+  num_senders( Range() ),
+  buffer_size( Range() ),
+  simulation_ticks( 1000000 )
+{
+}
 
+ConfigRange::ConfigRange( RemyBuffers::ConfigRange input_config ) :
+  link_ppt( Range( input_config.link_packets_per_ms() ) ),
+  rtt( Range( input_config.rtt() ) ),
+  mean_on_duration( Range( input_config.mean_on_duration() ) ),
+  mean_off_duration( Range( input_config.mean_off_duration() ) ),
+  num_senders( Range( input_config.num_senders() ) ),
+  buffer_size( Range( input_config.buffer_size() ) ),
+  simulation_ticks( input_config.simulation_ticks() )
+{
+}
+
+RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
 {
   RemyBuffers::ConfigRange ret;
   ret.mutable_link_packets_per_ms()->CopyFrom( pair_to_range( link_ppt) );

--- a/src/configrange.cc
+++ b/src/configrange.cc
@@ -20,7 +20,8 @@ RemyBuffers::ConfigRange ConfigRange::DNA( void ) const
   ret.mutable_num_senders()->CopyFrom( pair_to_range( num_senders ) );
   ret.mutable_mean_on_duration()->CopyFrom( pair_to_range( mean_on_duration ) );
   ret.mutable_mean_off_duration()->CopyFrom( pair_to_range( mean_off_duration ) );
-  ret.mutable_buffer_size()->CopyFrom( pair_to_range( buffer_size ) );  
+  ret.mutable_buffer_size()->CopyFrom( pair_to_range( buffer_size ) );
+  ret.set_simulation_ticks( simulation_ticks );
 
   return ret;
 }

--- a/src/configrange.hh
+++ b/src/configrange.hh
@@ -42,7 +42,8 @@ public:
   Range mean_off_duration = Range();
   Range num_senders = Range();
   Range buffer_size = Range();
- 
+  unsigned int simulation_ticks = 1000000;
+
   RemyBuffers::ConfigRange DNA( void ) const;
 };
 

--- a/src/configrange.hh
+++ b/src/configrange.hh
@@ -8,7 +8,7 @@ public:
   double low;
   double high;
   double incr;
-  Range ( void ) 
+  Range ( void )
     : low( 1 ),
       high ( 1 ),
       incr ( 0 )
@@ -36,14 +36,16 @@ public:
 class ConfigRange
 {
 public:
-  Range link_ppt = Range();
-  Range rtt = Range();
-  Range mean_on_duration = Range();
-  Range mean_off_duration = Range();
-  Range num_senders = Range();
-  Range buffer_size = Range();
-  unsigned int simulation_ticks = 1000000;
+  Range link_ppt;
+  Range rtt;
+  Range mean_on_duration;
+  Range mean_off_duration;
+  Range num_senders;
+  Range buffer_size;
+  unsigned int simulation_ticks;
 
+  ConfigRange( void );
+  ConfigRange( RemyBuffers::ConfigRange configrange );
   RemyBuffers::ConfigRange DNA( void ) const;
 };
 

--- a/src/evaluator.cc
+++ b/src/evaluator.cc
@@ -7,10 +7,9 @@
 #include "network.cc"
 #include "rat-templates.cc"
 
-const unsigned int TICK_COUNT = 1000000;
-
 Evaluator::Evaluator( const ConfigRange & range )
   : _prng_seed( global_PRNG()() ), /* freeze the PRNG seed for the life of this Evaluator */
+    _tick_count( range.simulation_ticks ),
     _configs()
 {
   // add configs from every point in the cube of configs
@@ -43,7 +42,7 @@ ProblemBuffers::Problem Evaluator::DNA( const WhiskerTree & whiskers ) const
 
   ProblemBuffers::ProblemSettings settings;
   settings.set_prng_seed( _prng_seed );
-  settings.set_tick_count( TICK_COUNT );
+  settings.set_tick_count( _tick_count );
 
   ret.mutable_settings()->CopyFrom( settings );
 
@@ -106,7 +105,7 @@ Evaluator::Outcome::Outcome( const AnswerBuffers::Outcome & dna )
 Evaluator::Outcome Evaluator::score( WhiskerTree & run_whiskers,
 				     const bool trace, const double carefulness ) const
 {
-  return score( run_whiskers, _prng_seed, _configs, trace, TICK_COUNT * carefulness );
+  return score( run_whiskers, _prng_seed, _configs, trace, _tick_count * carefulness );
 }
 
 

--- a/src/evaluator.hh
+++ b/src/evaluator.hh
@@ -29,6 +29,7 @@ public:
 
 private:
   const unsigned int _prng_seed;
+  unsigned int _tick_count;
 
   std::vector< NetConfig > _configs;
 

--- a/src/input-configrange.cc
+++ b/src/input-configrange.cc
@@ -74,6 +74,45 @@ bool update_config_with_range(RemyBuffers::Range * range, int argc,
   return true;
 }
 
+// Parses input arguments, sets a uint32 field.
+// If mandatory is false and no input arguments are found, skips and returns false.
+// If the input arugments are invalid, or if mandatory is true and no input arguments
+// are found, calls exit(1).
+// If all input arguments were found, updates the range and returns true.
+bool update_config_with_uint32(RemyBuffers::ConfigRange & range,
+    void (RemyBuffers::ConfigRange::*set_fn)(unsigned int), int argc, char *argv[],
+    string arg_name, bool mandatory) {
+
+  bool found = false;
+  unsigned int value = -1;
+  int arg_name_size = arg_name.size();
+  for ( int i = 1; i < argc; i++ ) {
+    string arg( argv[i] );
+    if ( arg.substr( 0, arg_name_size+1 ) == arg_name + "=" ) {
+      found = true;
+      try {
+        value = stoul( arg.substr( arg_name_size+1 ) );
+      } catch ( invalid_argument ) {
+        fprintf( stderr, "Could not parse %s argument: %s", arg_name.c_str(), arg.c_str() );
+        exit(1);
+      }
+      break;
+    }
+  }
+  if ( !found && mandatory ) {
+    fprintf( stderr, "Please provide an argument for %s\n", arg_name.c_str() );
+    exit(1);
+  }
+  if ( found ) {
+    fprintf( stderr, "Setting %s to %u\n", arg_name.c_str(), value );
+    (range.*set_fn)(value);
+    return true;
+  }
+  fprintf( stderr, "No argument found for %s\n", arg_name.c_str() );
+  return false;
+}
+
+
 int main(int argc, char *argv[]) {
   string input_filename, output_filename;
   bool infinite_buffers = false;
@@ -120,6 +159,8 @@ int main(int argc, char *argv[]) {
   update_config_with_range(input_config.mutable_num_senders(), argc, argv, "nsrc", mandatory);
   update_config_with_range(input_config.mutable_mean_on_duration(), argc, argv, "on", mandatory);
   update_config_with_range(input_config.mutable_mean_off_duration(), argc, argv, "off", mandatory);
+
+  update_config_with_uint32(input_config, &RemyBuffers::ConfigRange::set_simulation_ticks, argc, argv, "ticks", mandatory);
 
   if ( !(infinite_buffers) ) {
     update_config_with_range(input_config.mutable_buffer_size(), argc, argv, "buf_size", mandatory);

--- a/src/rat-runner.cc
+++ b/src/rat-runner.cc
@@ -20,6 +20,7 @@ int main( int argc, char *argv[] )
   double mean_on_duration = 5000.0;
   double mean_off_duration = 5000.0;
   double buffer_size = numeric_limits<unsigned int>::max();
+  unsigned int simulation_ticks = 1000000;
 
   for ( int i = 1; i < argc; i++ ) {
     string arg( argv[ i ] );
@@ -81,6 +82,8 @@ int main( int argc, char *argv[] )
   configuration_range.mean_on_duration = Range( mean_on_duration, mean_on_duration, 0 );
   configuration_range.mean_off_duration = Range( mean_off_duration, mean_off_duration, 0 );
   configuration_range.buffer_size = Range( buffer_size, buffer_size, 0 );
+  configuration_range.simulation_ticks = simulation_ticks;
+
   Evaluator eval( configuration_range );
   auto outcome = eval.score( whiskers, false, 10 );
   printf( "score = %f\n", outcome.score );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -92,12 +92,15 @@ int main( int argc, char *argv[] )
   options.config_range.mean_on_duration = Range( input_config.mean_on_duration() );
   options.config_range.mean_off_duration = Range( input_config.mean_off_duration() );
   options.config_range.buffer_size = Range( input_config.buffer_size() );
+  options.config_range.simulation_ticks = input_config.simulation_ticks();
 
   RatBreeder breeder( options );
 
   unsigned int run = 0;
 
   printf( "#######################\n" );
+  printf( "Evaluator simulations will run for %d ticks\n",
+    options.config_range.simulation_ticks );
   printf( "Optimizing for link packets_per_ms in [%f, %f]\n",
 	  options.config_range.link_ppt.low,
 	  options.config_range.link_ppt.high );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -11,6 +11,12 @@
 #include "configrange.hh"
 using namespace std;
 
+void print_range( const Range & range, const string & name )
+{
+  printf( "Optimizing for %s over [%f : %f : %f]\n", name.c_str(),
+    range.low, range.incr, range.high );
+}
+
 int main( int argc, char *argv[] )
 {
   WhiskerTree whiskers;
@@ -76,7 +82,7 @@ int main( int argc, char *argv[] )
         perror( "close" );
         exit( 1 );
       }
-    } 
+    }
   }
 
   if ( config_filename.empty() ) {
@@ -101,23 +107,17 @@ int main( int argc, char *argv[] )
   printf( "#######################\n" );
   printf( "Evaluator simulations will run for %d ticks\n",
     options.config_range.simulation_ticks );
-  printf( "Optimizing for link packets_per_ms in [%f, %f]\n",
-	  options.config_range.link_ppt.low,
-	  options.config_range.link_ppt.high );
-  printf( "Optimizing for rtt_ms in [%f, %f]\n",
-	  options.config_range.rtt.low,
-	  options.config_range.rtt.high );
-  printf( "Optimizing for num_senders in [%f, %f]\n",
-	  options.config_range.num_senders.low, options.config_range.num_senders.high );
-  printf( "Optimizing for mean_on_duration in [%f, %f], mean_off_duration in [ %f, %f]\n",
-	  options.config_range.mean_on_duration.low, options.config_range.mean_on_duration.high, options.config_range.mean_off_duration.low, options.config_range.mean_off_duration.high );
   printf( "Optimizing window increment: %d, window multiple: %d, intersend: %d\n",
           options.improver_options.optimize_window_increment, options.improver_options.optimize_window_multiple,
           options.improver_options.optimize_intersend);
+  print_range( options.config_range.link_ppt, "link packets_per_ms" );
+  print_range( options.config_range.rtt, "rtt_ms" );
+  print_range( options.config_range.num_senders, "num_senders" );
+  print_range( options.config_range.mean_on_duration, "mean_on_duration" );
+  print_range( options.config_range.mean_off_duration, "mean_off_duration" );
+
   if ( options.config_range.buffer_size.low != numeric_limits<unsigned int>::max() ) {
-    printf( "Optimizing for buffer_size in [%f, %f]\n",
-            options.config_range.buffer_size.low,
-            options.config_range.buffer_size.high );
+    print_range( options.config_range.buffer_size, "buffer_size" );
   } else {
     printf( "Optimizing for infinitely sized buffers. \n");
   }
@@ -147,7 +147,7 @@ int main( int argc, char *argv[] )
           RemyBuffers::NetConfig* net_config = training_configs.add_config();
           *net_config = run.first.DNA();
           written = true;
-      
+
         }
       }
       printf( "===\nconfig: %s\n", run.first.str().c_str() );

--- a/src/remy.cc
+++ b/src/remy.cc
@@ -91,14 +91,7 @@ int main( int argc, char *argv[] )
     exit ( 1 );
   }
 
-
-  options.config_range.link_ppt = Range( input_config.link_packets_per_ms() );
-  options.config_range.rtt = Range( input_config.rtt() );
-  options.config_range.num_senders = Range( input_config.num_senders() );
-  options.config_range.mean_on_duration = Range( input_config.mean_on_duration() );
-  options.config_range.mean_off_duration = Range( input_config.mean_off_duration() );
-  options.config_range.buffer_size = Range( input_config.buffer_size() );
-  options.config_range.simulation_ticks = input_config.simulation_ticks();
+  options.config_range = ConfigRange( input_config );
 
   RatBreeder breeder( options );
 


### PR DESCRIPTION
This adds the ability to replot existing results to the plot.py script, through a new `--replot` option. This option specifies a directory, and the script will then replot all the results from that directory, using the original rat-runner output files that were stored in it, along with any other (new) plots that are specified.

The only commit in this pull request that is not also in #31 is the last one.